### PR TITLE
DUP-28: Removed `version` key from library

### DIFF
--- a/iq_progressive_decoupler.libraries.yml
+++ b/iq_progressive_decoupler.libraries.yml
@@ -1,5 +1,4 @@
 initialize:
-  version: VERSION
   js:
     //cdnjs.cloudflare.com/ajax/libs/twig.js/0.8.9/twig.min.js: { type: external, minified: true }
     resources/js/twig-functions.js: {}

--- a/modules/iq_progressive_decoupler_rest_block/iq_progressive_decoupler_rest_block.libraries.yml
+++ b/modules/iq_progressive_decoupler_rest_block/iq_progressive_decoupler_rest_block.libraries.yml
@@ -1,5 +1,4 @@
 rest-block:
-  version: VERSION
   js:
     resources/js/init-rest-block.js: {}
 


### PR DESCRIPTION
We have `version: VERSION` set in our `*.libraries.yml` which leads to aggregated files always having the same hash and thus it is not guaranteed that cache is busted for clients/browsers. Remove it to solve the issue.